### PR TITLE
Revert "Pin Travis tests to WP_VERSION=4.7.3"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,19 +18,19 @@ cache:
 matrix:
   include:
     - php: 7.1
-      env: WP_VERSION=4.7.3
+      env: WP_VERSION=latest
     - php: 7.0
-      env: WP_VERSION=4.7.3
+      env: WP_VERSION=latest
     - php: 5.6
       env: WP_VERSION=4.4
     - php: 5.6
-      env: WP_VERSION=4.7.3
+      env: WP_VERSION=latest
     - php: 5.6
       env: WP_VERSION=trunk
     - php: 5.6
       env: WP_TRAVISCI=phpcs
     - php: 5.3
-      env: WP_VERSION=4.7.3
+      env: WP_VERSION=latest
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"


### PR DESCRIPTION
This reverts commit 62a82521a3b6cf5a3513c1240063122708248a96.

Fixes #5